### PR TITLE
Improve the docker image for nexus-configurator.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,3 @@ __pycache__
 *.egg-info
 .gitlab-ci.*
 .gitignore
-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - VCS_SOURCE="https://github.com/${TRAVIS_REPO_SLUG}"
   - secure: "KOEncoUStcCmiKviTz/u8KsiI5/+namjIZmkMsb2waYui1GyR+jeax0tmvKsKfDl8o3kxOFPbkHvXDpx8OlkAmB6QOWzciJjmWJsg0XDguafaQ3o0oZzPXekuJdIwm5m/fGRcdVHzdtDZawYMF+5uNegaiIUvIs9134njsuKMaK/WAOYLiMMMNWbjh0su8Zf57VBd++JrR8R33NTwp5WKrzhledGeSzMgir7xHb1N42/M/uw7PYOWGOigZaHMLBqCZ0q5w36hvUKTr+T6xqmiGCh5zCEARu7gHMLHpSvUuTGUUjX0clV/6R9pLdt43S5LVdX80pnw8viDgxxB3/zkQpYMp8osNYxFY7wpcUlRwoL4aLhKL5Zlc4cbn8EwQ+lZQGhGw6sAfV+p6pY5XxMREvReQEQxfu5aMXeq493ZFfzVvfZotkPvO9eFmsiyP67wQHDBE4XsVTWf2za84kmXhrB6MfxPSd2f10FM5TJgBcfJZ833lkJtEHHclYWdtVrUsVtDJf8tviCeAkQwkOvFJL8BGOVPyg7EUKpmKmGgeK0yyUDCUfjHFQNu7nk+NuxBU4W6j80TlT/lw7hw4j0tlMcWc5HbsI4P4jw0RQYrYrIRhPBgRmhS/c73+m9aORAfrduVsJ6HQyMfxV6rP6amPY++ZoF/8hTRYrKvqsCU1U="
 script:
-- ./build.sh
 - python setup.py test
 - ./.travis/docker-build.sh
 after_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
-FROM python:3.6-slim
+FROM alpine:3.7
+COPY build.sh /tmp
+WORKDIR /tmp
+RUN mkdir -p /tmp/nexus_configurator/groovy && \
+    apk update && \
+    apk add curl && \
+    ./build.sh
 
+FROM python:3.6-slim
 COPY . /app
 WORKDIR /app
+COPY --from=0 /tmp/nexus_configurator/groovy /app/nexus_configurator/groovy
 RUN pip install .
 USER nobody
 ENTRYPOINT ["nexus_configurator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:alpine3.6
+FROM python:3.6-slim
 
 COPY . /app
 WORKDIR /app
-RUN pip install pipenv && pipenv install
-ENV SHELL=/bin/sh
-ENTRYPOINT ["pipenv", "run", "nexus_configurator"]
+RUN pip install .
+USER nobody
+ENTRYPOINT ["nexus_configurator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM python:3.6-slim
 COPY . /app
 WORKDIR /app
 COPY --from=0 /tmp/nexus_configurator/groovy /app/nexus_configurator/groovy
-RUN pip install .
+RUN pip install pipenv && \
+    pipenv install --system --deploy
 USER nobody
 ENTRYPOINT ["nexus_configurator"]

--- a/bin/nexus_configurator
+++ b/bin/nexus_configurator
@@ -5,11 +5,13 @@ import jinja2
 import json
 import os
 import os.path
+from pkg_resources import resource_filename
 import sys
 import yaml
 from nexus_configurator.nexus import Nexus, NexusUnauthorised, NexusConnectionError
 
 ADMIN_USER = "admin"
+GROOVY_SCRIPTS_DIR = resource_filename("nexus_configurator", "groovy")
 
 
 class EnvDefault(argparse.Action):
@@ -51,7 +53,7 @@ def parse_args():
                         required=False)
     parser.add_argument("-g", "--groovy_dir",
                         help="directory containing groovy scripts to upload",
-                        default="groovy", action=EnvDefault,
+                        default=GROOVY_SCRIPTS_DIR, action=EnvDefault,
                         envvar="NEXUS_GROOVY_DIR")
     parser.add_argument("--config",
                         help="yaml configuration file path",

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 
 release="v2.1.2"
 rm -rf nexus3-*
+rm -rf nexus_configurator/groovy
 curl -L https://github.com/ansible-ThoTeam/nexus3-oss/archive/${release}.tar.gz | tar xz
 mv nexus3-* nexus3-oss
-ln -s nexus3-oss/files/groovy/ groovy
+ln -s ../nexus3-oss/files/groovy nexus_configurator/groovy

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-import glob
 
 setup(
   name='nexus_configurator',
@@ -14,5 +13,5 @@ setup(
   ],
   packages=['nexus_configurator'],
   scripts=['bin/nexus_configurator'],
-  data_files=[('groovy', glob.glob('groovy/*.groovy'))]
+  package_data={'nexus_configurator': ['groovy/*.groovy']}
 )


### PR DESCRIPTION
This pull request introduces two changes. The first one instructs the nexus_configurator script to use the groovy scripts from pkg_resources, making it independent from the current working directory. The second commit adjusts the Dockerfile to use a multi-stage build (https://docs.docker.com/develop/develop-images/multistage-build/), allowing the image to be built with the Dockerfile only, so the dockerhub automatic builds can be used instead of Travis CI.

Please see the commit messages for more details.